### PR TITLE
fix: Use dynamic directory path for artifact upload in test workflow

### DIFF
--- a/.github/workflows/test-measures.yml
+++ b/.github/workflows/test-measures.yml
@@ -98,9 +98,10 @@ jobs:
             --cache-control "max-age=0, no-cache, no-store, must-revalidate"
           echo "S3 sync complete."
           echo "https://${{ env.S3_BUCKET }}.s3.amazonaws.com/${{ env.DEPLOY_PATH }}/dashboard/index.html"
+          echo dir_name=$dir_name >> $GITHUB_ENV # Save the directory name to an environment variable for later use
 
       - name: Archive static site as artifact
         uses: actions/upload-artifact@v4
         with:
           name: static-html-artifact
-          path: ./test # Path should be relative to the GitHub workspace, which is shared with the container
+          path: ${{ env.dir_name }} # Path should be relative to the GitHub workspace, which is shared with the container


### PR DESCRIPTION
Use the saved directory name environment variable instead of hardcoded path for the artifact upload step, ensuring consistency with the actual build directory.